### PR TITLE
pd-mapper.service: Drop qrtr-ns dependency

### DIFF
--- a/pd-mapper.service.in
+++ b/pd-mapper.service.in
@@ -1,7 +1,5 @@
 [Unit]
 Description=Qualcomm PD mapper service
-Requires=qrtr-ns.service
-After=qrtr-ns.service
 
 [Service]
 ExecStart=PD_MAPPER_PATH/pd-mapper


### PR DESCRIPTION
qrtr-ns has moved to the kernel so we don't need the userland service.