### PR TITLE
pd-mapper.service: don't start if /sys/class/remoteproc is empty

### DIFF
--- a/pd-mapper.service.in
+++ b/pd-mapper.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Qualcomm PD mapper service
+ConditionDirectoryNotEmpty=/sys/class/remoteproc
 
 [Service]
 ExecStart=PD_MAPPER_PATH/pd-mapper


### PR DESCRIPTION
If there are no maps, pd-mapper always errors out with message "no pd maps available". This means the service fails and shows up as failed in systemctl --failed, which is ugly and annoying. For Fedora, it's also against the release criteria - there should be no failed services on startup of a default install, but on a default aarch64 install, this service usually fails.

To avoid this, let's add a condition saying not to try and start the service if /sys/class/remoteproc is not empty. Note this condition was added in systemd 244, but zbyzsek tells me that older systemd would not error out, it would just print a warning and ignore it, so that should be fine.